### PR TITLE
#167094602 create modal for deleting a flag from admin portal

### DIFF
--- a/UI/js/admin.js
+++ b/UI/js/admin.js
@@ -16,6 +16,42 @@ const token = sessionStorage.getItem('token');
 const urlPrefix = 'https://auto-mart-adc.herokuapp.com';
 
 /* ================ Helper funtions ================= */
+const deleteFlag = (params) => {
+  const {
+    id, car_name, owner_name, owner_id,
+  } = params;
+  const confirm = document.querySelector('#confirmation-overlay .yes');
+  const decline = document.querySelector('#confirmation-overlay .no');
+
+  confMsg.innerHTML = `Are you sure you want to delete<br/>flag with ID ${id} placed on<br/><b>${car_name}</b>
+  <br/>owned by ${(owner_id === parseInt(user_id, 10) ? 'you' : owner_name)}?`;
+  confirmationModal.style.display = 'block';
+
+  confirm.onclick = (e) => {
+    e.preventDefault();
+    const init = {
+      method: 'DELETE',
+      headers: { authorization: `Bearer ${token}` },
+    };
+    fetch(`${urlPrefix}/api/v1/flag/${id}`, init)
+    .then(res => res.json())
+    .then((response) => {
+      if (response.status === 200) {
+        message.innerHTML = response.message;
+        autoRefresh(3000);
+      } else {
+        message.innerHTML = response.error;
+      }
+      confirmationModal.style.display = 'none';
+      notificationModal.style.display = 'block';
+    });
+  };
+  decline.onclick = (e) => {
+    e.preventDefault();
+    confirmationModal.style.display = 'none';
+  };
+};
+
 const markAddressed = (params) => {
   const {
     id, car_name, owner_name, owner_id,
@@ -101,6 +137,11 @@ const viewFlagList = (carId, carName) => {
         };
         deleteFlagBtn.setAttribute('class', 'del-flag delete full-btn btn');
         deleteFlagBtn.innerHTML = 'Delete Flag';
+        deleteFlagBtn.onclick = () => {
+          deleteFlag({
+            id, car_name, owner_name, owner_id,
+          });
+        };
 
         btnGrp.setAttribute('class', 'flag-actions p-15');
         btnGrp.appendChild(markAddressedBtn);

--- a/UI/js/my-posted-ads.js
+++ b/UI/js/my-posted-ads.js
@@ -34,12 +34,12 @@ const deleteAd = (params) => {
     .then((response) => {
       if (response.status === 200) {
         message.innerHTML = response.message;
+        autoRefresh(3000);
       } else {
         message.innerHTML = response.error;
       }
       confirmationModal.style.display = 'none';
       notificationModal.style.display = 'block';
-      autoRefresh(3000);
     });
   };
   decline.onclick = (e) => {
@@ -85,13 +85,12 @@ const openUpdateModal = (params) => {
         message.innerHTML = `You have successfully updated the price for <b>${res.data.name}.</b><br/><br/>
         Old Price: &#8358 ${parseInt(price, 10).toLocaleString('en-US')}<br/>
         New Price: &#8358 ${parseInt(res.data.price, 10).toLocaleString('en-US')}`;
+        autoRefresh(3000);
       } else {
-        message.innerHTML = `${res.error}<br/>Please ensure you are logged-in before accessing this page.<br/>
-        If you don't have an account on AutoMart,<br/><a href='/api/v1/signup'>Click here to Sign-up.</a>`;
+        message.innerHTML = res.error;
       }
       updatePriceModal.style.display = 'none';
       notificationModal.style.display = 'block';
-      autoRefresh(3000);
     });
     return 0;
   };
@@ -117,13 +116,12 @@ const updateAdStatus = (params) => {
       const res = response;
       if (res.status === 200) {
         message.innerHTML = res.message;
+        autoRefresh(3000);
       } else {
-        message.innerHTML = `${res.error}<br/>Please ensure you are logged-in before accessing this page.<br/>
-        If you don't have an account on AutoMart,<br/><a href='/api/v1/signup'>Click here to Sign-up.</a>`;
+        message.innerHTML = res.error;
       }
       confirmationModal.style.display = 'none';
       notificationModal.style.display = 'block';
-      autoRefresh(3000);
     });
   };
   decline.onclick = (e) => {

--- a/UI/js/purchase-history.js
+++ b/UI/js/purchase-history.js
@@ -36,12 +36,12 @@ const deleteAd = (params) => {
     .then((response) => {
       if (response.status === 200) {
         message.innerHTML = response.message;
+        autoRefresh(3000);
       } else {
         message.innerHTML = response.error;
       }
       confirmationModal.style.display = 'none';
       notificationModal.style.display = 'block';
-      autoRefresh(3000);
     });
   };
   decline.onclick = (e) => {
@@ -91,13 +91,12 @@ const openUpdateModal = (params) => {
         Actual Price: &#8358 ${parseInt(res.data.price, 10).toLocaleString('en-US')}<br/>
         Old Price Offered: &#8358 ${parseInt(old_price_offered, 10).toLocaleString('en-US')}<br/>
         New Price Offered: &#8358 ${parseInt(new_price_offered, 10).toLocaleString('en-US')}`;
+        autoRefresh(3000);
       } else {
-        message.innerHTML = `${res.error}<br/>Please ensure you are logged-in before placing an order.<br/>
-        If you don't have an account on AutoMart,<br/><a href='/api/v1/signup'>Click here to Sign-up.</a>`;
+        message.innerHTML = res.error;
       }
       updatePriceModal.style.display = 'none';
       notificationModal.style.display = 'block';
-      autoRefresh(3000);
     });
     return 0;
   };

--- a/UI/js/sales-history.js
+++ b/UI/js/sales-history.js
@@ -34,6 +34,7 @@ const reactToOffer = (params) => {
         You have successfully <b>${action}ed</b> ${buyer_name}'s offer for
         <b>${car_name}</b><br/>Price of Car: ${parseInt(price, 10).toLocaleString('en-US')}<br/>
         Price Offered: ${parseInt(price_offered, 10).toLocaleString('en-US')}`;
+        autoRefresh(3000);
       } else {
         message.innerHTML = response.error;
       }
@@ -129,7 +130,7 @@ window.onload = () => {
     }
   })
   .catch((error) => {
-    message.innerHTML = `${error}<br/>Ensure you are connected to the internet.<br/>Click on Close to refresh page.`;
+    message.innerHTML = `${error}<br/>Ensure you are connected to the internet.<br/>Then, refresh page.`;
     notificationModal.style.display = 'block';
     toggleScroll();
   });
@@ -138,5 +139,4 @@ window.onload = () => {
 closeNotifation.onclick = (e) => {
   e.preventDefault();
   notificationModal.style.display = 'none';
-  autoRefresh(0);
 };


### PR DESCRIPTION
#### What does this PR do?
Create modal for deleting a flag from the admin portal

#### Description of Task to be completed?'

- enable admins to delete a flag attached to a car Ad
- consume the API endpoint '/api/v1/flag/:flag_id' for deleting a flag
- stop page reload if a resource is not updated

#### How should this be manually tested?

- clone this repo, cd to the root directory.
- locate the UI folder, then the template folder inside it.
- double click on the signin.html file to open it on your default browser so you can log in if you have an account.
- log in with an admin account
- click on the 'View Flags' button on any of the car Ad, then the delete button if it has flags

#### Any background context you want to provide?
#### What are the relevant pivotal tracker stories?
[#167094602](https://www.pivotaltracker.com/story/show/167094602)

#### Screenshots (if appropriate)
#### Questions: