### PR TITLE
#167021438 add reset password page that doesn't require the request body

### DIFF
--- a/UI/js/reset-password.js
+++ b/UI/js/reset-password.js
@@ -1,0 +1,77 @@
+const email = document.getElementById('email');
+
+const errorDiv = document.getElementById('error-div');
+const resetPass = document.getElementById('reset-pass-btn');
+
+const urlPrefix = 'https://auto-mart-adc.herokuapp.com';
+
+let success = false;
+
+// Validation function
+const validateForm = () => {
+	const errorFields = [];
+	if (email.value === '') errorFields.push('no-email');
+	else if (!(/\S+@\S+\.\S+/.test(email.value))) {
+		errorFields.push('bad-email');
+	}
+	return errorFields;
+};
+
+resetPass.onclick = (e) => {
+	e.preventDefault();
+	errorDiv.style.display = 'none';
+	errorDiv.style.backgroundColor = '#a45';
+	const errors = validateForm();
+	if (errors.length > 0) {
+		let errMsg = '';
+		errors.map((err) => {
+			switch (err) {
+				case 'no-email':
+					errMsg += 'email cannot be empty<br/>';
+					break;
+				case 'bad-email':
+					errMsg += 'your e-mail is badly formed<br/>';
+					break;
+				default: errMsg += 'check if all your entry is correct<br/>';
+			}
+			errorDiv.style.display = 'block';
+			errorDiv.innerHTML = errMsg;
+			return 0;
+		});
+	} else {
+		// process the form
+		resetPass.innerHTML = 'Processing data...';
+		resetPass.disabled = 'disabled';
+		const options = {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+		};
+
+		fetch(`${urlPrefix}/api/v1/user/${email.value}/reset_password`, options)
+		.then((res) => {
+			if (res.status === 204) {
+				success = true;
+				return 0;
+			}
+			return res.json();
+		})
+		.then((response) => {
+			if (response.status !== 204) {
+				errorDiv.innerHTML = response.error;
+			}
+		})
+		.catch((err) => {
+			errorDiv.innerHTML = err;
+		})
+		.finally(() => {
+			if (success) {
+				errorDiv.style.backgroundColor = '#4b5';
+				errorDiv.innerHTML = `You have successfully reset your password.
+				The reset password has been sent to the email you entered.`;
+			}
+			errorDiv.style.display = 'block';
+			resetPass.innerHTML = 'Reset Password';
+			resetPass.disabled = null;
+		});
+	}
+};

--- a/UI/templates/reset-password.html
+++ b/UI/templates/reset-password.html
@@ -4,7 +4,7 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width initial-scale=1.0">
 		<meta name="description" content="Sign in page for Auto-Mart">
-		<title>Sign In - Auto Mart</title>
+		<title>Password Reset - Auto Mart</title>
 
 		<link href="https://fonts.googleapis.com/css?family=Oxygen" rel="stylesheet">
 		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/all.min.css">
@@ -24,6 +24,7 @@
 						<ul class="menu-list">
 							<li><a href="./marketplace.html">Marketplace</a></li>
 							<li><a href="https://auto-mart-adc.herokuapp.com/api/v1/api-doc" target="_blank">API Doc</a></li>
+							<li><a href="./signin.html">Sign In</a></li>
 							<li><a href="./signup.html">Sign Up</a></li>
 						</ul>
 					</div>
@@ -31,21 +32,16 @@
 			</header>
 			<main class="main-100">
 				<div class="signin-form-container">
-					<h1>Sign In</h1>
+					<h1>Password Reset</h1>
 					<form>
 						<div>
+							<p>Enter your registered email address here.<br/>A reset password will be sent to you via the email.</p>
 							<div class = "input-field single">
 								<label for="email">E-mail:</label>
 								<input type="email" id="email" name="email" autofocus/>
 							</div>
-							<div class = "input-field single">
-								<label for="password">Password:</label>
-								<input type="password" id="password" name="password"/>
-								<a href="./reset-password.html">Forget Password?</a>
-							</div>
 							<div id="error-div" class="hide"></div>
-							<button id="signin-btn" class="full-btn btn">Sign In</button>
-							<p class="end-note">New to Auto Mart, <a href="./signup">Create New Account</a></p>
+							<button id="reset-pass-btn" class="full-btn btn">Reset Password</button>
 						</div>
 					</form>
 				</div>
@@ -68,6 +64,6 @@
 
 		<!-- scripts -->
 		<script src="../js/general.js"></script>
-		<script src="../js/signin.js"></script>
+		<script src="../js/reset-password.js"></script>
 	</body>
 </html>


### PR DESCRIPTION
#### What does this PR do?
Add reset password page that doesn't require the request body

#### Description of Task to be completed?'

- add the reset password page used when a user cannot remember his/her password
- consume the API endpoint '/api/v1/user/:email/reset_password' for resetting password

#### How should this be manually tested?

- clone this repo, cd to the root directory.
- locate the UI folder, then the template folder inside it.
- double click on the signin.html file to open it on your default browser
- click on the 'Forgot Password' link under the password field

#### Any background context you want to provide?
#### What are the relevant pivotal tracker stories?
[#167021438](https://www.pivotaltracker.com/story/show/167021438)

#### Screenshots (if appropriate)
#### Questions: